### PR TITLE
[WIP] Move webtorrent to its own process

### DIFF
--- a/app/browser/webtorrent.js
+++ b/app/browser/webtorrent.js
@@ -1,0 +1,102 @@
+const electron = require('electron')
+const ipc = electron.ipcMain
+const messages = require('../../js/constants/messages')
+const WebTorrent = require('webtorrent')
+
+var DEBUG_IPC = false // Set to see communication between WebTorrent and torrent viewer tabs
+var ANNOUNCE = [
+  'wss://tracker.btorrent.xyz',
+  'wss://tracker.openwebtorrent.com',
+  'wss://tracker.fastcast.nz'
+]
+
+var client = null
+var channels = {}
+
+ipc.on(messages.TORRENT_MESSAGE, function (e, msg) {
+  if (DEBUG_IPC) console.log('Received IPC: ' + JSON.stringify(msg))
+  channels[msg.channelID] = e.sender
+  handleMessage(msg)
+})
+
+function handleMessage (msg) {
+  switch (msg.type) {
+    case 'add':
+      return handleAdd(msg)
+    default:
+      // Sanity check. Is there a better way to do error logging in the browser process?
+      console.error('Ignoring unknown action ' + msg.type + ', channel ' + msg.channelID)
+  }
+}
+
+function handleAdd (msg) {
+  var torrent = lazyClient().add(msg.torrentID, {
+    announce: ANNOUNCE
+  })
+  if (torrent.channelID) throw new Error('torrent already has a channelID')
+  // TODO: handle the case where two different tabs (two different channels)
+  // both open the same infohash
+  torrent.channelID = msg.channelID
+  addTorrentEvents(torrent)
+}
+
+function addClientEvents () {
+  client.on('error', function (err) {
+    sendToAllChannels({errorMessage: err.message})
+  })
+}
+
+function addTorrentEvents (torrent) {
+  torrent.on('infohash', () => sendInfo(torrent))
+  torrent.on('metadata', () => sendInfo(torrent))
+  torrent.on('progress', () => sendProgress(torrent))
+  torrent.on('done', () => sendProgress(torrent))
+}
+
+function sendProgress (torrent) {
+  send({
+    type: 'progress',
+    channelID: torrent.channelID,
+    progress: torrent.progress
+  })
+}
+
+function sendInfo (torrent) {
+  var msg = {
+    type: 'info',
+    channelID: torrent.channelID,
+    torrent: {
+      name: torrent.name,
+      infohash: torrent.infohash,
+      progress: torrent.progress,
+      files: []
+    }
+  }
+  if (torrent.files) {
+    msg.torrent.files = torrent.files.map(function (file) {
+      return {
+        name: file.name
+      }
+    })
+  }
+  send(msg)
+}
+
+function send (msg) {
+  if (DEBUG_IPC) console.log('Sending IPC: ' + JSON.stringify(msg))
+  channels[msg.channelID].send(messages.TORRENT_MESSAGE, msg)
+}
+
+function sendToAllChannels (msg) {
+  for (var channelID in channels) {
+    var channelMsg = Object.assign({}, msg, {channelID})
+    send(channelMsg)
+  }
+}
+
+function lazyClient () {
+  if (client) return client
+  client = new WebTorrent()
+  addClientEvents()
+  return client
+}

--- a/app/index.js
+++ b/app/index.js
@@ -82,6 +82,7 @@ const basicAuth = require('./browser/basicAuth')
 const async = require('async')
 const tabs = require('./browser/tabs')
 const settings = require('../js/constants/settings')
+require('./browser/webtorrent')
 
 // temporary fix for #4517, #4518 and #4472
 app.commandLine.appendSwitch('enable-use-zoom-for-dsf', 'false')

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -881,8 +881,29 @@ class Frame extends ImmutableComponent {
           method = (currentDetail, originalDetail) =>
             windowActions.setAutofillCreditCardDetail(currentDetail, originalDetail)
           break
+        case messages.TORRENT_MESSAGE:
+          // Relay torrent IPC from the webview to a browser process
+          method = (message) => {
+            if (typeof message.channelID !== 'string') {
+              throw new Error('Invalid or missing channelID: ' + JSON.stringify(message))
+            }
+            if (this.torrentChannelID && this.torrentChannelID !== message.channelID) {
+              throw new Error('ChannelID changed, expected ' + this.torrentChannelID +
+                ': ' + JSON.stringify(message))
+            }
+            this.torrentChannelID = message.channelID
+            ipc.send(messages.TORRENT_MESSAGE, message)
+          }
+          break
       }
       method.apply(this, e.args)
+    })
+
+    // Relay torrent IPC from the browser process back to the webview
+    ipc.on(messages.TORRENT_MESSAGE, (e, obj) => {
+      // Ignore the message if it's for a different tab
+      if (obj.channelID !== this.torrentChannelID) return
+      this.webview.send(messages.TORRENT_MESSAGE, obj)
     })
 
     const interceptFlash = (stopCurrentLoad, adobeUrl, redirectUrl) => {

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -150,7 +150,9 @@ const messages = {
   LEDGER_UPDATED: _,
   LEDGER_CREATE_WALLET: _,
   CHECK_BITCOIN_HANDLER: _,
-  ADD_FUNDS_CLOSED: _
+  ADD_FUNDS_CLOSED: _,
+  // Torrent
+  TORRENT_MESSAGE: _
 }
 
 module.exports = mapValuesByKeys(messages)


### PR DESCRIPTION
For now, that's the main browser process. In the future, it'll be a separate utility process. The important parts:
* It's a single process with a single instance of WebTorrent, not one per tab
* It has access to the Node APIs, which allow WebTorrent to talk to the millions of standard BitTorrent clients out there

### Work left to do in this PR
- **Pull the WebTorrent remote API into its own module.** I'll make a module called `webtorrent-remote` soon. This means we can re-use work we already did in WebTorrent Desktop and get a nice clean separation of concerns.
- **Security review.**

### Future work, won't be in this PR
- **Support WebRTC in addition to standard BitTorrent.** Currently, the only good, non-flaky WebRTC implementation we have access to is Chromium's WebRTC stack, which is only available in renderer processes. Conversely, the Node APIs are only available in the browser process. (This is due to Brave's security features, different from vanilla Electron.) Ideally, WebTorrent would run in a utility process similar to a vanilla Electron renderer process: with access to both the Node APIs and WebRTC. For now, we support standard BitTorrent only, no WebRTC.

@bbondy @bridiver @feross @diracdeltas @BrendanEich